### PR TITLE
Fix to deno 178 removal of node/fs

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -5,6 +5,7 @@
     "preact/": "https://esm.sh/preact@10.8.2/",
     "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.0?deps=preact@10.8.2",
     "remult": "https://cdn.skypack.dev/remult@latest?dts",
-    "remult/remult-fresh": "https://cdn.skypack.dev/remult@latest/remult-fresh?dts"
+    "remult/remult-fresh": "https://cdn.skypack.dev/remult@latest/remult-fresh?dts",
+    "https://deno.land/std/node/fs.ts": "https://deno.land/std@0.177.0/node/fs.ts"
   }
 }


### PR DESCRIPTION
Skypack automatically replace reference to "fs" with "https://deno.land/std/node/fs.ts" that was removed in the latest release of "deno" last week. See:
https://github.com/skypackjs/skypack-cdn/issues/342

Until skypack fixes it, this import map fix resolves the problem.

This may solve #4 